### PR TITLE
fix : student_conversation input box with large input length

### DIFF
--- a/frontend/public/assets/css/student_discussion.css
+++ b/frontend/public/assets/css/student_discussion.css
@@ -207,6 +207,9 @@ body {
     width: 50%;
     height: 100%;
 
+    border-color: transparent;
+    outline: none;
+
 
 }
 
@@ -345,6 +348,7 @@ body {
     outline: none;
 
 }
+
 
 .send-file-btn{
 
@@ -635,11 +639,24 @@ body {
 
 }
 
+textarea{
+
+    text-align: justify;
+    word-break: break-all;
+    resize: none;
+    
+
+}
+
+.send-message textarea{
+    height: 50%;
+}
+
 .send-message {
 
     border-radius: 3rem;
-    justify-content: flex-start;
-    align-self: center;
+    justify-content: center;
+    align-items: center;
     display:flex;
 
     

--- a/frontend/public/assets/js/student_conversation.js
+++ b/frontend/public/assets/js/student_conversation.js
@@ -96,9 +96,9 @@ async function SendMessage() {
         "<div class='sent_ID'>" +
         username +
         "</div>" +
-        "<div class='sent_content'>" +
+        "<textarea class='sent_content' disabled>" +
         message +
-        "</div>" +
+        "</textarea >" +
         "</div>";
 
     conversation_box.scrollTop = conversation_box.scrollHeight;
@@ -122,9 +122,9 @@ async function SendMessage() {
             "<div class='sent_ID' style='text-align: left;'>" +
             "小助手" +
             "</div>" +
-            "<div class='sent_content' style='background: var(--status_y_50, #FFF6E8);'>" +
+            "<textarea class='sent_content' style='background: var(--status_y_50, #FFF6E8);'>" +
             response_message +
-            "</div>" +
+            "</textarea>" +
             "</div>";
     }
     conversation_box.scrollTop = conversation_box.scrollHeight;

--- a/frontend/public/student_conversation.html
+++ b/frontend/public/student_conversation.html
@@ -112,7 +112,7 @@
         </div>
 
         <div class="send-message">
-          <input onkeydown="detectEnter(this)" id="message" class="message" type="text" placeholder="輸入訊息" />
+          <textarea onkeydown="detectEnter(this)" id="message" class="message" type="text" placeholder="輸入訊息"></textarea>
           <button class="send-button" onclick="SendMessage()"></button>
         </div>
       </div>


### PR DESCRIPTION
* 修復測試報告書中提到即時聊天輸入欄若輸入字串過長會超過整個頁面
  * 取而代之的是會自動換行的 textarea 設定
* 修復測試報告書中提到即時聊天輸出結果（對話紀錄）也有同樣的問題
  * 解決方案承上